### PR TITLE
fix: do not force-set `req.destroyed = true` on abort

### DIFF
--- a/src/request-base.js
+++ b/src/request-base.js
@@ -501,10 +501,6 @@ RequestBase.prototype.abort = function () {
       throw new Error(
         'Superagent does not work in v13 properly with abort() due to Node.js core changes'
       );
-    } else if (semver.gte(process.version, 'v14.0.0')) {
-      // We have to manually set `destroyed` to `true` in order for this to work
-      // (see core internals of end-of-stream.js above in v14 branch as compared to v12)
-      this.req.destroyed = true;
     }
 
     this.req.abort(); // node


### PR DESCRIPTION
The current `this.req.destroyed = true` hack that was added in https://github.com/ladjs/superagent/commit/8b1923d4a0f22bec49ec6eebead499ce0ac7f694 actually breaks the behavior of 14.0.0.

Looking at [`v14.0.0`'s HTTP client's code](https://github.com/nodejs/node/blob/73aa21658dfa6a22c06451d080152b32b1f98dbe/lib/_http_client.js#L341-L368), the `abort` method internally calls `destroy`. 

`destroy` has an early termination when `destroyed` is already `true`. Setting `destroyed = true` before calling `abort()` stops Node.js from internally closing the socket, potentially leading to memory leaks.

It also breaks the behavior of `abort()` since Node.js deprecated it in favor of `destroy()` (as Node.js internally relies on `destroy()` logic to terminate the call.

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
