### PR TITLE
fix: handle BigInts that has a .toJSON property

### DIFF
--- a/src/request-base.js
+++ b/src/request-base.js
@@ -662,7 +662,8 @@ RequestBase.prototype.send = function (data) {
   // merge
   if (isObject_ && isObject(this._data)) {
     for (const key in data) {
-      if (typeof data[key] == "bigint") throw new Error("Cannot serialize BigInt value to json");
+      if (typeof data[key] == 'bigint' && !data[key].toJSON)
+        throw new Error('Cannot serialize BigInt value to json');
       if (hasOwn(data, key)) this._data[key] = data[key];
     }
   }

--- a/test/json.js
+++ b/test/json.js
@@ -132,6 +132,32 @@ describe('req.send(Object) as "json"', function () {
     done();
   });
 
+  describe('when BigInts have a .toJSON property', function () {
+    before(function () {
+      // eslint-disable-next-line node/no-unsupported-features/es-builtins
+      BigInt.prototype.toJSON = function () {
+        return this.toString();
+      };
+    });
+
+    it('should accept BigInt properties', (done) => {
+      request
+        .post(`${uri}/echo`)
+        .send({ number: 1n })
+        .end((error, res) => {
+          res.should.be.json();
+          res.text.should.equal('{"number":"1"}');
+          done();
+        });
+    });
+
+    after(function () {
+      // eslint-disable-next-line node/no-unsupported-features/es-builtins
+      delete BigInt.prototype.toJSON;
+    });
+  });
+
+
   it('should error for BigInt primitive', (done) => {
     try {
       request


### PR DESCRIPTION
## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.

## Problem

The recent changes introduced in https://github.com/ladjs/superagent/pull/1773 restricts the usage of `BigInt` with the `.send()` method, even if the `BigInt` object has a `.toJSON` method. In scenarios where developers want to serialize `BigInt` properties to JSON, this becomes a limitation.

## Change

This pull request modifies the existing checks on `BigInt` values passed to the `.send()` method. With this change, if a `BigInt` property has a `.toJSON` method, it will not throw the "Cannot serialize BigInt value to json" error.