### PR TITLE
chore: use single export

### DIFF
--- a/src/node/parsers/index.js
+++ b/src/node/parsers/index.js
@@ -1,11 +1,14 @@
-exports['application/x-www-form-urlencoded'] = require('./urlencoded');
-exports['application/json'] = require('./json');
-exports.text = require('./text');
+const urlencoded = require('./urlencoded.js');
+const json = require('./json.js');
+const text = require('./text.js');
+const binary = require('./image.js');
 
-exports['application/json-seq'] = exports.text;
-
-const binary = require('./image');
-
-exports['application/octet-stream'] = binary;
-exports['application/pdf'] = binary;
-exports.image = binary;
+module.exports = {
+  'application/x-www-form-urlencoded': urlencoded,
+  'application/json': json,
+  'text': text,
+  'application/json-seq': text,
+  'application/octet-stream': binary,
+  'application/pdf': binary,
+  'image': binary
+}


### PR DESCRIPTION
I'm going to try and [group export](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/group-exports.md) and put them at the bottom [last](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/exports-last.md) and also using explicit path (with extension) cuz this really makes it much more easier to refactor the code into ESM at a later stage.

It's much more easier to see what things gets exported when they are put last as a group

## Checklist

- [x] I have ensured my pull request is not behind the **_beta_** branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
