### PR TITLE
Update qs dep to ^6.2.4 for prototype poisoning security fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "formidable": "^2.1.2",
     "methods": "^1.1.2",
     "mime": "2.6.0",
-    "qs": "^6.11.0",
+    "qs": "^6.2.4",
     "semver": "^7.3.8"
   },
   "devDependencies": {


### PR DESCRIPTION
## Changes
`qs < 6.2.4` has a [major security issue](https://security.snyk.io/vuln/SNYK-JS-QS-3153490), which this simple bump to `qs ^6.2.4` would resolve. I chose the minimum version possible with this sec fix to avoid any breaking changes, however, the lib should be brought to current in a more thorough change as well. 

## Context
```
[qs](https://www.npmjs.com/package/qs) is a querystring parser that supports nesting and arrays, with a depth limit.

Affected versions of this package are vulnerable to Prototype Poisoning which allows attackers to cause a Node process to hang, processing an Array object whose prototype has been replaced by one with an excessive length value.

Note: In many typical Express use cases, an unauthenticated remote attacker can place the attack payload in the query string of the URL that is used to visit the application, such as a[__proto__]=b&a[__proto__]&a[length]=100000000.
```

## Checklist

🚧 Awaiting workflow approval to confirm CI & linting runs 

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [ ] I have ensured that my code changes pass linting tests.
- [ ] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
