### PR TITLE
docs: no longer recommend `polyfill.io`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Browser-ready versions of this module are available via [jsdelivr][], [unpkg][],
 This is the solution for you if you're just using `<script>` tags everywhere!
 
 ```html
-<script src="https://polyfill.io/v3/polyfill.min.js?features=WeakRef,BigInt"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=WeakRef,BigInt"></script>
 <script src="https://cdn.jsdelivr.net/npm/superagent"></script>
 <!-- if you wish to use unpkg.com instead: -->
 <!-- <script src="https://unpkg.com/superagent"></script> -->
@@ -155,10 +155,10 @@ If you are using [browserify][], [webpack][], [rollup][], or another bundler, th
 
 ### Required Browser Features
 
-We recommend using <https://polyfill.io> (specifically with the bundle mentioned in [VanillaJS](#vanillajs) above):
+We recommend using <https://cdnjs.cloudflare.com/polyfill/> (specifically with the bundle mentioned in [VanillaJS](#vanillajs) above):
 
 ```html
-<script src="https://polyfill.io/v3/polyfill.min.js?features=WeakRef,BigInt"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=WeakRef,BigInt"></script>
 ```
 
 * WeakRef is not supported in Opera 85, iOS Safari 12.2-12.5

--- a/docs/index.md
+++ b/docs/index.md
@@ -868,10 +868,10 @@ Libraries like [co](https://github.com/tj/co) or a web framework like [koa](http
 
 Note that SuperAgent expects the global `Promise` object to be present. You'll need to use v7 and a polyfill to use promises in Internet Explorer or Node.js 0.10.
 
-We have dropped support in v8 for IE.  You must add a polyfill for WeakRef and BigInt if you wish to support Opera 85, iOS Safari 12.2-12.5, for example using <https://polyfill.io>:
+We have dropped support in v8 for IE.  You must add a polyfill for WeakRef and BigInt if you wish to support Opera 85, iOS Safari 12.2-12.5, for example using <https://cdnjs.cloudflare.com/polyfill/>:
 
 ```html
-<script src="https://polyfill.io/v3/polyfill.min.js?features=WeakRef,BigInt"></script>
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=WeakRef,BigInt"></script>
 ```
 
 ## Browser and node versions

--- a/index.html
+++ b/index.html
@@ -623,8 +623,8 @@ Tobi
     const res = yield req;
 </code></pre>
 <p>Note that SuperAgent expects the global <code>Promise</code> object to be present. You&#39;ll need to use v7 and a polyfill to use promises in Internet Explorer or Node.js 0.10.</p>
-<p>We have dropped support in v8 for IE.  You must add a polyfill for WeakRef and BigInt if you wish to support Opera 85, iOS Safari 12.2-12.5, for example using <a href="https://polyfill.io">https://polyfill.io</a>:</p>
-<pre><code class="language-html">&lt;script src=&quot;https://polyfill.io/v3/polyfill.min.js?features=WeakRef,BigInt&quot;&gt;&lt;/script&gt;
+<p>We have dropped support in v8 for IE.  You must add a polyfill for WeakRef and BigInt if you wish to support Opera 85, iOS Safari 12.2-12.5, for example using <a href="https://cdnjs.cloudflare.com/polyfill/">https://cdnjs.cloudflare.com/polyfill/</a>:</p>
+<pre><code class="language-html">&lt;script src=&quot;https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=WeakRef,BigInt&quot;&gt;&lt;/script&gt;
 </code></pre>
 <h2 id="browser-and-node-versions">Browser and node versions</h2>
 <p>SuperAgent has two implementations: one for web browsers (using XHR) and one for Node.JS (using core http module). By default Browserify and WebPack will pick the browser version.</p>


### PR DESCRIPTION
## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [ ] I have ensured that my code changes pass linting tests.
- [ ] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.

---

Replace the `polyfill.io` with `cdnjs.cloudflare.com/polyfill` in the README and the docs:

`polyfill.io` was acquired by **a China-based CDN company** "Funnull", see [the announcement from the `polyfill.io` domain owner's Twitter](https://x.com/JakeDChampion/status/1761315227008643367) and https://github.com/polyfillpolyfill/polyfill-service/issues/2834. Despite Funnull's claims of operating in the United States, the predominance of Simplified Chinese on its website suggests otherwise, and it turns out that **"Funnull" is notorious for providing service for the betting and pornography industries**.

[The original creator of the `polyfill.io` has voiced his concern on Twitter](https://twitter.com/triblondon/status/1761852117579427975). And since the acquisition, numerous issues have emerged (https://github.com/polyfillpolyfill/polyfill-service/issues/2835, https://github.com/polyfillpolyfill/polyfill-service/issues/2838, https://github.com/alist-org/alist/issues/6100), rendering the `polyfill.io` service **extremely unstable**. Since then, Fastly ([Announcement](https://community.fastly.com/t/new-options-for-polyfill-io-users/2540)) and Cloudflare ([Announcement](https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk)) has hosted their own instances of `polyfill.io` service.
