### PR TITLE
fix: unify body and query serialisation behaviour

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -192,7 +192,9 @@ request.types = {
  */
 
 request.serialize = {
-  'application/x-www-form-urlencoded': qs.stringify,
+  'application/x-www-form-urlencoded': (obj) => {
+    return qs.stringify(obj, { indices: false, strictNullHandling: true });
+  },
   'application/json': safeStringify
 };
 

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -98,7 +98,9 @@ exports.protocols = {
  */
 
 exports.serialize = {
-  'application/x-www-form-urlencoded': qs.stringify,
+  'application/x-www-form-urlencoded': (obj) => {
+    return qs.stringify(obj, { indices: false, strictNullHandling: true });
+  },
   'application/json': safeStringify
 };
 

--- a/test/client/serialize.js
+++ b/test/client/serialize.js
@@ -38,6 +38,7 @@ describe('request.serializeObject()', () => {
     serialize({ '&name&': 'tj' }, '%26name%26=tj');
     serialize({ hello: '`test`' }, 'hello=%60test%60');
     serialize({ $hello: 'test' }, '$hello=test');
+    serialize({ foo: 'foo', foo: 'bar' }, 'foo=foo&foo=bar');
   });
 });
 


### PR DESCRIPTION
## Because

#1591 changed things to use `qs` to serialise form data. However, that change set `qs.stringify` as the body serialisation function i.e. default options. The existing query serialisation uses `qs.stringify` with `indices: false` and `strictNullHandling: true` options.

Existing documentation indicates that body serialisation with duplicated object keys should result in the same behaviour as the existing query serialisation. However, `qs.stringify` with default options results in a different outcome, as described in the issue this PR closes.

## This PR

- Changes body serialisation function to match existing query serialisation function and options
- Adds test for serialising duplicated keys

## Linked issue

Closes #1798

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
