### PR TITLE
fix: 'hexoid is not a function' when using webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "debug": "^4.3.4",
     "fast-safe-stringify": "^2.1.1",
     "form-data": "^4.0.0",
-    "formidable": "^3.5.1",
+    "formidable": "^3.5.2",
     "methods": "^1.1.2",
     "mime": "2.6.0",
     "qs": "^6.11.0"


### PR DESCRIPTION
This fixes #1786 which was (mistakenly?) marked as fixed. It's a long-standing issue when using superagent with webpack. 

Root Cause: The transitive [hexoid](https://www.npmjs.com/package/hexoid) dependency exports were invalid and broke webpack.

Related Links:

* https://github.com/lukeed/hexoid/issues/7
* https://github.com/node-formidable/formidable/issues/871
* https://github.com/node-formidable/formidable/issues/981
* https://github.com/node-formidable/formidable/pull/982

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [ ] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.

Master isn't passing for me locally.
